### PR TITLE
add working recording functionality

### DIFF
--- a/client.py
+++ b/client.py
@@ -1,8 +1,0 @@
-from socketIO_client import SocketIO
-
-def on_aaa_response(*args):
-    print('on_aaa_response', args)
-
-with SocketIO('localhost', 6000) as SocketIO:
-    socketIO.on('aaa_response', on_aaa_response)
-    socketIO.emit('aaa')


### PR DESCRIPTION
When the camera client starts, it connects to the server via SocketIO
and TCP, and starts streaming the recording trough the TCP socket.
The server has a job timed with cron, which emits a command to the
camera, saying that it should split the recording now and reopen the TCP
socket, forcing the server to finish the recording of the previous file,
close it and start when the new TCP socket is up, stream it's contents
into a new file.
